### PR TITLE
Iteration 3 refactor 2

### DIFF
--- a/lib/latin_document.rb
+++ b/lib/latin_document.rb
@@ -16,10 +16,14 @@ class LatinDocument
   def add_breaks (line)
     output = []
     while (line.length > 40)
-      nonsense = line.slice!(0..40) # backlog - if we slice at the end of a word this may shorten a perfect 40 character line?
-      readable = nonsense.rpartition(" ") #finds last instance of a space, returns three part array
+      nonsense = line.slice!(0..39)
+      if !nonsense.include?(" ") #to tolerate words long than 40 chars
+        output << nonsense
+        next
+      end
+      readable = nonsense.rpartition(" ")
       output << readable[0]
-      line.prepend(readable[2]) #add back the beginning of whatever word we just cut in half with line.slice
+      line.prepend(readable[2])
     end
     output << line
   end
@@ -38,7 +42,6 @@ class LatinDocument
   def get_translation
     parse_lines
     result = ""
-     # @parsed_lines.map! {|line| Line.new(line)}
      @parsed_lines.each do |line|
       translated_line = @rosetta.translate_line_latin_to_braille(line)
       result += translated_line
@@ -52,5 +55,5 @@ class LatinDocument
     text.each_line {|line| count += line.chomp.length}
     output = count / 6
   end
-  
+
 end

--- a/spec/latin_document_spec.rb
+++ b/spec/latin_document_spec.rb
@@ -48,4 +48,20 @@ RSpec.describe LatinDocument do
     expect(expected.lines[3].length).to eq(11)
   end
 
+  it "keeps existing multiple line breaks" do
+    doc = LatinDocument.new("this test has\n\ntwo paragraphs")
+    expected = doc.get_translation
+
+    expect(expected.lines.length).to eq(9)
+    expect(expected.lines[4]).to eq("\n")
+  end
+
+  it "keeps existing multiple spaces" do
+    doc = LatinDocument.new("so many             spaces")
+    expected = doc.get_translation
+
+    expect(expected.lines[0].length).to eq(53)
+    expect(expected.lines[0][14..39]).to eq("..........................")
+  end
+
 end

--- a/spec/latin_document_spec.rb
+++ b/spec/latin_document_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe LatinDocument do
     expect(@document.length).to eq(47) # -1 space when line break is added
   end
 
+  it "breaks words longer than 40 characters onto two lines" do
+    doc = LatinDocument.new("pneumonoultramicroscopicsilicovolcanoconiosis")
+    expected = doc.get_translation
+    expect(expected.lines[0].length).to eq(81)
+    expect(expected.lines[3].length).to eq(11)
+  end
+
 end


### PR DESCRIPTION
This refactor addresses a few edge cases;
- verifies that chained line breaks will be preserved by the code
- verifies that chained spaces will be preserved by the code, however;
  - in the case where `add_breaks` needs to break in the middle of these spaces, one of them WILL still be removed
- modifies LatinDocument such that input words longer than 40 characters will be continued on the next line after 40 characters (fixes infinite looping issue)